### PR TITLE
Pane7 Icon Pack - a Windows 7 Icon Pack for Windows 10

### DIFF
--- a/themes.yaml
+++ b/themes.yaml
@@ -327,3 +327,8 @@
       name: Windows 11 New Folders Slate
     - path: themes/icons/niivu/Windows 11 New Folders Yellow.zip
       name: Windows 11 New Folders Yellow
+- author: ImSwordQueen
+  link: https://github.com/ImSwordQueen
+  themes:
+    - path: themes/icons/ImSwordQueen/Pane7.zip
+      name: Pane7


### PR DESCRIPTION
Pane7 is an icon pack that adds Windows 7 icons to Windows 10 (Untested on 11. Might have some leftover 11 icons there.)

I added the credits of all the people involved in the theme.ini file but i'm going to post them here as well:

Microsoft Corporation - Copyright of all the Windows 7 resources.
ImSwordQueen - Creator of this pack and the 21H2to7 TP which this pack is based off.
kfh83 - NTMU Adaption
travis (travy-patty) - 7TSP Version